### PR TITLE
убрал ошибку

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 include_directories(src)
 
-aux_source_directory(./src ${SRCS})
+aux_source_directory(./src SRCS)
 
 add_executable(Engine ${SRCS})
 


### PR DESCRIPTION
Мелкая была ошибка в вызове `aux_source_directory`: вместо того, чтобы дать ей "объявить" `SRCS`, она записывала в несуществующую переменную. 